### PR TITLE
Fix: log library staff as -999 if nil

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,9 +28,21 @@ namespace :csv_load do
       t.student_teacher_ratio = row['student_teacher_ratio']
       t.instructional_aides = row['instructional_aides']
       t.guidance_counselors = row['guidance_counselors']
-      t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+
+      if t.guidance_counselors == 0
+        t.student_guidance_counselor_ratio = -999
+      else
+        t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+      end
+
       t.librarian_total = row['librarian_total']
-      t.student_librarian_ratio = row['student_librarian_ratio']
+
+      if t.librarian_total == 0
+        t.student_librarian_ratio = -999
+      else
+        t.student_librarian_ratio = row['student_librarian_ratio']
+      end
+
       t.total_staff = row['total_staff']
       t.district_expense_total = row['district_expense_total']
       t.expenses_for_instruction = row['expenses_for_instruction']
@@ -60,9 +72,21 @@ namespace :csv_load do
       t.student_teacher_ratio = row['student_teacher_ratio']
       t.instructional_aides = row['instructional_aides']
       t.guidance_counselors = row['guidance_counselors']
-      t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+
+      if t.guidance_counselors == 0
+        t.student_guidance_counselor_ratio = -999
+      else
+        t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+      end
+
       t.librarian_total = row['librarian_total']
-      t.student_librarian_ratio = row['student_librarian_ratio']
+
+      if t.librarian_total == 0
+        t.student_librarian_ratio = -999
+      else
+        t.student_librarian_ratio = row['student_librarian_ratio']
+      end
+
       t.total_staff = row['total_staff']
       t.district_expense_total = row['district_expense_total']
       t.expenses_for_instruction = row['expenses_for_instruction']
@@ -92,9 +116,21 @@ namespace :csv_load do
       t.student_teacher_ratio = row['student_teacher_ratio']
       t.instructional_aides = row['instructional_aides']
       t.guidance_counselors = row['guidance_counselors']
-      t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+
+      if t.guidance_counselors == 0
+        t.student_guidance_counselor_ratio = -999
+      else
+        t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+      end
+
       t.librarian_total = row['librarian_total']
-      t.student_librarian_ratio = row['student_librarian_ratio']
+
+      if t.librarian_total == 0
+        t.student_librarian_ratio = -999
+      else
+        t.student_librarian_ratio = row['student_librarian_ratio']
+      end
+      
       t.total_staff = row['total_staff']
       t.district_expense_total = row['district_expense_total']
       t.expenses_for_instruction = row['expenses_for_instruction']
@@ -124,9 +160,21 @@ namespace :csv_load do
       t.student_teacher_ratio = row['student_teacher_ratio']
       t.instructional_aides = row['instructional_aides']
       t.guidance_counselors = row['guidance_counselors']
-      t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+
+      if t.guidance_counselors == 0
+        t.student_guidance_counselor_ratio = -999
+      else
+        t.student_guidance_counselor_ratio = row['student_guidance_counselor_ratio']
+      end
+
       t.librarian_total = row['librarian_total']
-      t.student_librarian_ratio = row['student_librarian_ratio']
+
+      if t.librarian_total == 0
+        t.student_librarian_ratio = -999
+      else
+        t.student_librarian_ratio = row['student_librarian_ratio']
+      end
+      
       t.total_staff = row['total_staff']
       t.district_expense_total = row['district_expense_total']
       t.expenses_for_instruction = row['expenses_for_instruction']

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -1,6 +1,6 @@
 class District < ApplicationRecord
-  validates :name, presence: true, allow_nil: true
-  validates :lea_id, presence: true, allow_nil: true
+  validates :name, presence: true
+  validates :lea_id, presence: true
   validates :urban_centric_locale, presence: true, allow_nil: true
   validates :number_of_schools_in_district, presence: true, allow_nil: true
   validates :enrollment, presence: true, allow_nil: true

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -1,28 +1,28 @@
 class District < ApplicationRecord
-  validates :name, presence: true
-  validates :lea_id, presence: true
-  validates :urban_centric_locale, presence: true
-  validates :number_of_schools_in_district, presence: true
-  validates :enrollment, presence: true
-  validates :pre_k_teachers, presence: true
-  validates :kindergarten_teachers, presence: true
-  validates :elementary_teachers, presence: true
-  validates :secondary_teachers, presence: true
-  validates :total_teachers, presence: true
-  validates :student_teacher_ratio, presence: true
-  validates :instructional_aides, presence: true
-  validates :guidance_counselors, presence: true
-  validates :student_guidance_counselor_ratio, presence: true
-  validates :librarian_total, presence: true
-  validates :student_librarian_ratio, presence: true
-  validates :total_staff, presence: true
-  validates :district_expense_total, presence: true
-  validates :expenses_for_instruction, presence: true
-  validates :salaries_total, presence: true
-  validates :salaries_instruction, presence: true
-  validates :instruction_salary_percent_of_total, presence: true
-  validates :per_student_expenditure, presence: true
-  validates :per_teacher_salary_expenses, presence: true
+  validates :name, presence: true, allow_nil: true
+  validates :lea_id, presence: true, allow_nil: true
+  validates :urban_centric_locale, presence: true, allow_nil: true
+  validates :number_of_schools_in_district, presence: true, allow_nil: true
+  validates :enrollment, presence: true, allow_nil: true
+  validates :pre_k_teachers, presence: true, allow_nil: true
+  validates :kindergarten_teachers, presence: true, allow_nil: true
+  validates :elementary_teachers, presence: true, allow_nil: true
+  validates :secondary_teachers, presence: true, allow_nil: true
+  validates :total_teachers, presence: true, allow_nil: true
+  validates :student_teacher_ratio, presence: true, allow_nil: true
+  validates :instructional_aides, presence: true, allow_nil: true
+  validates :guidance_counselors, presence: true, allow_nil: true
+  validates :student_guidance_counselor_ratio, presence: true, allow_nil: true
+  validates :librarian_total, presence: true, allow_nil: true
+  validates :student_librarian_ratio, presence: true, allow_nil: true
+  validates :total_staff, presence: true, allow_nil: true
+  validates :district_expense_total, presence: true, allow_nil: true
+  validates :expenses_for_instruction, presence: true, allow_nil: true
+  validates :salaries_total, presence: true, allow_nil: true
+  validates :salaries_instruction, presence: true, allow_nil: true
+  validates :instruction_salary_percent_of_total, presence: true, allow_nil: true
+  validates :per_student_expenditure, presence: true, allow_nil: true
+  validates :per_teacher_salary_expenses, presence: true, allow_nil: true
 
   has_many :user_districts
   has_many :users, through: :user_districts

--- a/app/poros/district_enrollment.rb
+++ b/app/poros/district_enrollment.rb
@@ -42,7 +42,14 @@ class DistrictEnrollment
 
     @instructional_aides_total = data[:results].first[:instructional_aides_fte]
 
-    @guidance_counselors_total = data[:results].first[:guidance_counselors_total_fte]
+    if data[:results].first[:guidance_counselors_total_fte].nil?
+      @guidance_counselors_total = -999
+      @student_guidance_counselor_ratio = -999
+    else
+      @guidance_counselors_total = data[:results].first[:guidance_counselors_total_fte]
+      @student_guidance_counselor_ratio = (@enrollment.to_f / @guidance_counselors_total.to_f).round(2)
+    end
+
 
     if (data[:results].first[:librarian_specialists_fte]).nil?
       @total_library_staff = -999
@@ -52,7 +59,7 @@ class DistrictEnrollment
       @student_librarian_ratio = (@enrollment.to_f / @total_library_staff).round(2)
     end
 
-    @student_guidance_counselor_ratio = (@enrollment.to_f / @guidance_counselors_total.to_f).round(2)
+
 
     @total_staff = data[:results].first[:staff_total_fte]
   end

--- a/app/poros/district_enrollment.rb
+++ b/app/poros/district_enrollment.rb
@@ -44,9 +44,13 @@ class DistrictEnrollment
 
     @guidance_counselors_total = data[:results].first[:guidance_counselors_total_fte]
 
-    @total_library_staff = (data[:results].first[:librarian_specialists_fte])
-
-    @student_librarian_ratio = (@enrollment.to_f / @total_library_staff).round(2)
+    if (data[:results].first[:librarian_specialists_fte]).nil?
+      @total_library_staff = -999
+      @student_librarian_ratio = -999
+    else
+      @total_library_staff = (data[:results].first[:librarian_specialists_fte])
+      @student_librarian_ratio = (@enrollment.to_f / @total_library_staff).round(2)
+    end
 
     @student_guidance_counselor_ratio = (@enrollment.to_f / @guidance_counselors_total.to_f).round(2)
 


### PR DESCRIPTION
## Pull request type
Describe the purpose of this PR(other):

- Some states don't keep track of library staff, breaking the data pulling for those districts. This logs it as -999 instead of nil to solve that. 
